### PR TITLE
Add PDF export with pdfmake

### DIFF
--- a/frontend/src/LegacyApp.js
+++ b/frontend/src/LegacyApp.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
 import axios from "axios";
+import { generateQuotePDF, generateInvoicePDF } from './utils/pdf';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 const API = `${BACKEND_URL}/api`;
@@ -3696,6 +3697,12 @@ const Quotes = ({ user, sessionToken }) => {
                         {quote.status === 'sent' ? 'Envoyé' : 'Envoyer'}
                       </button>
                     )}
+                    <button
+                      onClick={() => generateQuotePDF(quote)}
+                      className="btn btn-outline btn-sm"
+                    >
+                      📄 PDF
+                    </button>
                   </div>
                 </div>
               </div>
@@ -4317,7 +4324,7 @@ const Invoices = ({ user, sessionToken }) => {
                       </button>
                     )}
                     <button
-                      onClick={() => {/* TODO: Generate PDF */}}
+                      onClick={() => generateInvoicePDF(invoice)}
                       className="btn btn-outline btn-sm"
                     >
                       📄 PDF

--- a/frontend/src/utils/pdf.js
+++ b/frontend/src/utils/pdf.js
@@ -1,2 +1,95 @@
-export function generateQuotePDF() {}
-export function generateInvoicePDF() {}
+import pdfMake from 'pdfmake/build/pdfmake';
+import pdfFonts from 'pdfmake/build/vfs_fonts';
+
+pdfMake.vfs = pdfFonts.pdfMake.vfs;
+
+function buildItemsTable(items) {
+  const body = [
+    ['Description', 'Qté', 'PU', 'Total'],
+    ...items.map((item) => [
+      item.description,
+      { text: item.quantity.toString(), alignment: 'right' },
+      { text: item.unit_price.toFixed(2) + '€', alignment: 'right' },
+      { text: item.total.toFixed(2) + '€', alignment: 'right' }
+    ])
+  ];
+  return {
+    table: { headerRows: 1, widths: ['*', 'auto', 'auto', 'auto'], body },
+    layout: 'lightHorizontalLines',
+    margin: [0, 10, 0, 10]
+  };
+}
+
+export function generateQuotePDF(quote) {
+  const docDefinition = {
+    content: [
+      { text: `Devis ${quote.quote_number}`, style: 'header' },
+      { text: quote.client_name, style: 'subheader' },
+      buildItemsTable(quote.items),
+      {
+        columns: [
+          { width: '*', text: '' },
+          {
+            width: 'auto',
+            table: {
+              body: [
+                ['Sous-total', `${quote.subtotal.toFixed(2)}€`],
+                [
+                  `TVA (${quote.tax_rate}%)`,
+                  `${quote.tax_amount.toFixed(2)}€`
+                ],
+                [{ text: 'Total', bold: true }, { text: `${quote.total.toFixed(2)}€`, bold: true }]
+              ]
+            },
+            layout: 'noBorders'
+          }
+        ]
+      }
+    ],
+    styles: {
+      header: { fontSize: 18, bold: true, margin: [0, 0, 0, 10] },
+      subheader: { fontSize: 14, margin: [0, 0, 0, 10] }
+    }
+  };
+
+  pdfMake.createPdf(docDefinition).open();
+}
+
+export function generateInvoicePDF(invoice) {
+  const docDefinition = {
+    content: [
+      { text: `Facture ${invoice.invoice_number}`, style: 'header' },
+      { text: invoice.client_name, style: 'subheader' },
+      buildItemsTable(invoice.items),
+      {
+        columns: [
+          { width: '*', text: '' },
+          {
+            width: 'auto',
+            table: {
+              body: [
+                ['Sous-total', `${invoice.subtotal.toFixed(2)}€`],
+                [
+                  `TVA (${invoice.tax_rate}%)`,
+                  `${invoice.tax_amount.toFixed(2)}€`
+                ],
+                [
+                  { text: 'Total', bold: true },
+                  { text: `${invoice.total.toFixed(2)}€`, bold: true }
+                ]
+              ]
+            },
+            layout: 'noBorders'
+          }
+        ]
+      }
+    ],
+    styles: {
+      header: { fontSize: 18, bold: true, margin: [0, 0, 0, 10] },
+      subheader: { fontSize: 14, margin: [0, 0, 0, 10] }
+    }
+  };
+
+  pdfMake.createPdf(docDefinition).open();
+}
+

--- a/test_result.md
+++ b/test_result.md
@@ -331,4 +331,5 @@ agent_communication:
   - agent: "main"
     message: "🔧 PHASE 4 DÉMARRÉE : Corrections finales Planning et complétion Devis & Factures : 1) Correction alignement exact heures 9h-18h 2) Ajustement couleurs cartes revenus selon spécifications 3) Transitions fade plus discrètes 4) Ajout export PDF pour devis/factures 5) Tests backend complets."
   - agent: "main"
-    message: "Nettoyage final du module Planning : suppression complète de la page 'Tâches'. Toutes les fonctionnalités de tâches restent dans la vue Planning."
+    message: "Nettoyage final du module Planning : suppression complète de la page 'Tâches'. Toutes les fonctionnalités de tâches restent dans la vue Planning."- agent: "main"
+  message: "Implemented client-side PDF generation for quotes and invoices using pdfmake"


### PR DESCRIPTION
## Summary
- generate PDFs for quotes and invoices via `pdfmake`
- expose `generateQuotePDF` and `generateInvoicePDF` utilities and wire buttons
- log change in `test_result.md`

## Testing
- `yarn test` *(fails: Couldn't find script)*
- `python backend_test.py` *(fails: blocked network access)*


------
https://chatgpt.com/codex/tasks/task_e_68838a24c1f883339022f608ec651306