### PR TITLE
Fix routing and sidebar

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,10 +1,12 @@
 import React, { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Layout from './components/Layout';
 
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 const Planning = lazy(() => import('./pages/Planning'));
 const Quotes = lazy(() => import('./pages/Quotes'));
 const Invoices = lazy(() => import('./pages/Invoices'));
+const Clients = lazy(() => import('./pages/Clients'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
 function App() {
@@ -12,11 +14,14 @@ function App() {
     <BrowserRouter>
       <Suspense fallback={<div className="p-6">Loading...</div>}>
         <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/planning" element={<Planning />} />
-          <Route path="/quotes" element={<Quotes />} />
-          <Route path="/invoices" element={<Invoices />} />
-          <Route path="*" element={<NotFound />} />
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="planning" element={<Planning />} />
+            <Route path="quotes" element={<Quotes />} />
+            <Route path="invoices" element={<Invoices />} />
+            <Route path="clients" element={<Clients />} />
+            <Route path="*" element={<NotFound />} />
+          </Route>
         </Routes>
       </Suspense>
     </BrowserRouter>

--- a/frontend/src/LegacyApp.js
+++ b/frontend/src/LegacyApp.js
@@ -4335,6 +4335,7 @@ export {
   Planning,
   Quotes,
   Invoices,
+  Clients,
   EventModal,
   TaskModal,
   WeekNavigationHeader,

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import axios from 'axios';
+import Sidebar from './Sidebar';
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+export default function Layout() {
+  const [user, setUser] = useState(null);
+  const [sessionToken, setSessionToken] = useState(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('fleemy_session_token');
+    async function check() {
+      if (token) {
+        try {
+          const response = await axios.get(`${API}/auth/me`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          setUser(response.data);
+          setSessionToken(token);
+        } catch (e) {
+          localStorage.removeItem('fleemy_session_token');
+        }
+      }
+    }
+    check();
+  }, []);
+
+  const handleLogout = () => {
+    localStorage.removeItem('fleemy_session_token');
+    setUser(null);
+    setSessionToken(null);
+  };
+
+  return (
+    <div className="flex min-h-screen bg-gray-50">
+      <Sidebar user={user} onLogout={handleLogout} />
+      <main className="flex-1 overflow-auto p-6">
+        <Outlet context={{ user, sessionToken }} />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const menuItems = [
+  { id: 'dashboard', name: 'Dashboard', icon: '📊', to: '/' },
+  { id: 'planning', name: 'Planning', icon: '📅', to: '/planning' },
+  { id: 'quotes', name: 'Devis', icon: '📋', to: '/quotes' },
+  { id: 'invoices', name: 'Factures', icon: '🧾', to: '/invoices' },
+  { id: 'clients', name: 'Clients', icon: '👥', to: '/clients' },
+];
+
+export default function Sidebar({ user, onLogout }) {
+  return (
+    <div className="w-64 bg-white shadow-lg border-r border-gray-200 flex flex-col min-h-screen">
+      <div className="p-6 border-b border-gray-200">
+        <div className="flex items-center space-x-3">
+          <div className="text-2xl">📊</div>
+          <div>
+            <h1 className="text-xl font-bold text-gray-800">Fleemy</h1>
+            <p className="text-xs text-gray-500">Outil tout-en-un</p>
+          </div>
+        </div>
+      </div>
+      <nav className="flex-1 p-4">
+        <ul className="space-y-2">
+          {menuItems.map((item) => (
+            <li key={item.id}>
+              <NavLink
+                to={item.to}
+                end={item.to === '/'}
+                className={({ isActive }) =>
+                  `w-full flex items-center space-x-3 px-4 py-3 rounded-lg transition-all ${
+                    isActive
+                      ? 'bg-blue-100 text-blue-700 border border-blue-200'
+                      : 'text-gray-600 hover:bg-gray-100'
+                  }`
+                }
+              >
+                <span className="text-lg">{item.icon}</span>
+                <span className="font-medium">{item.name}</span>
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      {user && (
+        <div className="p-4 border-t border-gray-200">
+          <div className="flex items-center space-x-3 mb-3">
+            <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold text-sm">
+              {user.name ? user.name.charAt(0).toUpperCase() : ''}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-800 truncate">
+                {user.name ?? ''}
+              </p>
+              <p className="text-xs text-gray-500 truncate">{user.email ?? ''}</p>
+            </div>
+          </div>
+          {onLogout && (
+            <button
+              onClick={onLogout}
+              className="w-full text-left text-sm text-gray-500 hover:text-gray-700 px-2 py-1 rounded"
+            >
+              Se déconnecter
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Clients.jsx
+++ b/frontend/src/pages/Clients.jsx
@@ -1,0 +1,7 @@
+import { Clients as LegacyClients } from '../LegacyApp';
+import { useOutletContext } from 'react-router-dom';
+
+export default function Clients() {
+  const { user, sessionToken } = useOutletContext();
+  return <LegacyClients user={user} sessionToken={sessionToken} />;
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,2 +1,7 @@
-import { Dashboard } from '../LegacyApp';
-export default Dashboard;
+import { Dashboard as LegacyDashboard } from '../LegacyApp';
+import { useOutletContext } from 'react-router-dom';
+
+export default function Dashboard() {
+  const { user, sessionToken } = useOutletContext();
+  return <LegacyDashboard user={user} sessionToken={sessionToken} />;
+}

--- a/frontend/src/pages/Invoices.jsx
+++ b/frontend/src/pages/Invoices.jsx
@@ -1,2 +1,7 @@
-import { Invoices } from '../LegacyApp';
-export default Invoices;
+import { Invoices as LegacyInvoices } from '../LegacyApp';
+import { useOutletContext } from 'react-router-dom';
+
+export default function Invoices() {
+  const { user, sessionToken } = useOutletContext();
+  return <LegacyInvoices user={user} sessionToken={sessionToken} />;
+}

--- a/frontend/src/pages/Planning.jsx
+++ b/frontend/src/pages/Planning.jsx
@@ -1,2 +1,7 @@
-import { Planning } from '../LegacyApp';
-export default Planning;
+import { Planning as LegacyPlanning } from '../LegacyApp';
+import { useOutletContext } from 'react-router-dom';
+
+export default function Planning() {
+  const { user, sessionToken } = useOutletContext();
+  return <LegacyPlanning user={user} sessionToken={sessionToken} />;
+}

--- a/frontend/src/pages/Quotes.jsx
+++ b/frontend/src/pages/Quotes.jsx
@@ -1,2 +1,7 @@
-import { Quotes } from '../LegacyApp';
-export default Quotes;
+import { Quotes as LegacyQuotes } from '../LegacyApp';
+import { useOutletContext } from 'react-router-dom';
+
+export default function Quotes() {
+  const { user, sessionToken } = useOutletContext();
+  return <LegacyQuotes user={user} sessionToken={sessionToken} />;
+}


### PR DESCRIPTION
## Summary
- export `Clients` from LegacyApp
- create Sidebar with `NavLink` highlighting
- add Layout wrapper to manage session and display sidebar
- pass user/session via outlet context to pages
- add missing Clients page and update routes

## Testing
- `npm start`
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b4c92e348333889ec3eda03a8f9a