### PR TITLE
Fix monthly calendar grid

### DIFF
--- a/frontend/src/components/MonthCalendar.jsx
+++ b/frontend/src/components/MonthCalendar.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import '../styles/MonthCalendar.css';
+
+function MonthCalendar({ year, month }) {
+  const daysOfWeek = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche'];
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDay = new Date(year, month, 1).getDay();
+  const offset = (firstDay + 6) % 7; // adjust so Monday=0
+  const cells = [];
+
+  for (let i = 0; i < offset; i++) {
+    cells.push(null);
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push(d);
+  }
+  while (cells.length < 42) {
+    cells.push(null);
+  }
+
+  const rows = [];
+  for (let i = 0; i < 6; i++) {
+    rows.push(cells.slice(i * 7, i * 7 + 7));
+  }
+
+  return (
+    <div className="month-calendar">
+      <div className="calendar-header">
+        {daysOfWeek.map((day) => (
+          <div key={day} className="calendar-header-cell">
+            {day}
+          </div>
+        ))}
+      </div>
+      <div className="calendar-grid">
+        {rows.map((week, wi) => (
+          <div key={wi} className="calendar-row">
+            {week.map((value, di) => (
+              value ? (
+                <div key={di} className="calendar-cell">{value}</div>
+              ) : (
+                <div key={di} className="calendar-cell empty" />
+              )
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default MonthCalendar;

--- a/frontend/src/styles/MonthCalendar.css
+++ b/frontend/src/styles/MonthCalendar.css
@@ -1,0 +1,28 @@
+.month-calendar {
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-header, .calendar-row {
+  display: flex;
+}
+
+.calendar-header-cell, .calendar-cell {
+  flex: 1;
+  height: 80px;
+  border: 1px solid #e5e7eb;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.calendar-header-cell {
+  font-weight: 600;
+  background: #f9fafb;
+}
+
+.calendar-cell.empty {
+  background: #fafafa;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add standalone `MonthCalendar` component
- provide matching styles for consistent grid cells

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm start` *(fails if port 3000 already used)*

------
https://chatgpt.com/codex/tasks/task_e_688491b0f0b8833396b8d6757a6b00e6