### PR TITLE
Fix modals saving logic and unify API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Frontend
-REACT_APP_BACKEND_URL=http://localhost:8000
+REACT_APP_API_URL=http://localhost:8000
 REACT_APP_AUTH_URL=http://localhost:8000/auth
 
 # Backend

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
-REACT_APP_BACKEND_URL=http://localhost:8000
+REACT_APP_API_URL=http://localhost:8000
 REACT_APP_AUTH_URL=http://localhost:8000/auth

--- a/frontend/src/LegacyApp.js
+++ b/frontend/src/LegacyApp.js
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
-import axios from "axios";
+import api from "./utils/api";
+import { showToast } from "./utils/toast";
 import { generateQuotePDF, generateInvoicePDF } from "./utils/pdf";
 import WeekNavigationHeader from "./components/WeekNavigationHeader";
-
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
 
 // Utility functions
 const formatDate = (date) => {
@@ -168,11 +166,11 @@ const Dashboard = ({ user, sessionToken }) => {
   const [loading, setLoading] = useState(true);
 
   const apiCall = async (url, options = {}) => {
-    return await axios({
-      url: `${API}${url}`,
+    return await api({
+      url,
       headers: {
         Authorization: `Bearer ${sessionToken}`,
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         ...options.headers,
       },
       ...options,
@@ -1418,11 +1416,11 @@ const Planning = ({ user, sessionToken }) => {
 
   const apiCall = async (url, options = {}) => {
     try {
-      return await axios({
-        url: `${API}${url}`,
+      return await api({
+        url,
         headers: {
           Authorization: `Bearer ${sessionToken}`,
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
           ...options.headers,
         },
         ...options,
@@ -2036,6 +2034,9 @@ const Planning = ({ user, sessionToken }) => {
         end: eventData.end,
       };
 
+      console.log(`Élément enregistré avec succès (ID: ${response.data.id})`);
+      showToast(`Élément enregistré avec succès (ID: ${response.data.id})`);
+
       setEvents((prevEvents) => [...prevEvents, newEvent]);
       setEventModal({
         isOpen: false,
@@ -2050,6 +2051,10 @@ const Planning = ({ user, sessionToken }) => {
       }, 100);
     } catch (error) {
       console.error("Error creating event:", error);
+      showToast(
+        `Erreur: ${error.response?.data?.detail || error.message}`,
+        true
+      );
       // If offline, save locally only
       if (!isOnline) {
         const eventToCreateLocal = {
@@ -2089,6 +2094,12 @@ const Planning = ({ user, sessionToken }) => {
         method: "PUT",
         data: updateData,
       });
+      console.log(
+        `Élément enregistré avec succès (ID: ${eventModal.event.id})`
+      );
+      showToast(
+        `Élément enregistré avec succès (ID: ${eventModal.event.id})`
+      );
 
       // Update local state immediately
       setEvents((prevEvents) =>
@@ -2113,6 +2124,10 @@ const Planning = ({ user, sessionToken }) => {
       });
     } catch (error) {
       console.error("Error updating event:", error);
+      showToast(
+        `Erreur: ${error.response?.data?.detail || error.message}`,
+        true
+      );
     }
   };
 
@@ -2156,11 +2171,15 @@ const Planning = ({ user, sessionToken }) => {
         },
       });
 
+      console.log(`Élément enregistré avec succès (ID: ${response.data.id})`);
+      showToast(`Élément enregistré avec succès (ID: ${response.data.id})`);
+
       // Update local state immediately
       setTasks((prevTasks) => [...prevTasks, response.data]);
       setTaskModal({ isOpen: false, task: null });
     } catch (error) {
       console.error("Error creating task:", error);
+      showToast(`Erreur: ${error.response?.data?.detail || error.message}`, true);
     }
   };
 
@@ -2177,6 +2196,13 @@ const Planning = ({ user, sessionToken }) => {
         },
       });
 
+      console.log(
+        `Élément enregistré avec succès (ID: ${taskModal.task.id})`
+      );
+      showToast(
+        `Élément enregistré avec succès (ID: ${taskModal.task.id})`
+      );
+
       // Update local state immediately
       setTasks((prevTasks) =>
         prevTasks.map((task) =>
@@ -2187,6 +2213,7 @@ const Planning = ({ user, sessionToken }) => {
       setTaskModal({ isOpen: false, task: null });
     } catch (error) {
       console.error("Error updating task:", error);
+      showToast(`Erreur: ${error.response?.data?.detail || error.message}`, true);
     }
   };
 
@@ -2701,11 +2728,11 @@ const TodoList = ({ sessionToken }) => {
   });
 
   const apiCall = async (url, options = {}) => {
-    return await axios({
-      url: `${API}${url}`,
+    return await api({
+      url,
       headers: {
         Authorization: `Bearer ${sessionToken}`,
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         ...options.headers,
       },
       ...options,
@@ -3086,11 +3113,11 @@ const Quotes = ({ user, sessionToken }) => {
   const [quoteTemplates, setQuoteTemplates] = useState([]);
 
   const apiCall = async (url, options = {}) => {
-    return await axios({
-      url: `${API}${url}`,
+    return await api({
+      url,
       headers: {
         Authorization: `Bearer ${sessionToken}`,
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         ...options.headers,
       },
       ...options,
@@ -3129,6 +3156,12 @@ const Quotes = ({ user, sessionToken }) => {
           method: "PUT",
           data: quoteData,
         });
+        console.log(
+          `Élément enregistré avec succès (ID: ${editingQuote.id})`
+        );
+        showToast(
+          `Élément enregistré avec succès (ID: ${editingQuote.id})`
+        );
         setQuotes((prevQuotes) =>
           prevQuotes.map((q) =>
             q.id === editingQuote.id ? { ...q, ...quoteData } : q
@@ -3139,11 +3172,18 @@ const Quotes = ({ user, sessionToken }) => {
           method: "POST",
           data: quoteData,
         });
+        console.log(
+          `Élément enregistré avec succès (ID: ${response.data.id})`
+        );
+        showToast(
+          `Élément enregistré avec succès (ID: ${response.data.id})`
+        );
         setQuotes((prevQuotes) => [response.data, ...prevQuotes]);
       }
       setShowQuoteModal(false);
     } catch (error) {
       console.error("Error saving quote:", error);
+      showToast(`Erreur: ${error.response?.data?.detail || error.message}`, true);
     }
   };
 
@@ -3827,11 +3867,11 @@ const Invoices = ({ user, sessionToken }) => {
   const [editingInvoice, setEditingInvoice] = useState(null);
 
   const apiCall = async (url, options = {}) => {
-    return await axios({
-      url: `${API}${url}`,
+    return await api({
+      url,
       headers: {
         Authorization: `Bearer ${sessionToken}`,
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         ...options.headers,
       },
       ...options,
@@ -3873,6 +3913,12 @@ const Invoices = ({ user, sessionToken }) => {
           method: "PUT",
           data: invoiceData,
         });
+        console.log(
+          `Élément enregistré avec succès (ID: ${editingInvoice.id})`
+        );
+        showToast(
+          `Élément enregistré avec succès (ID: ${editingInvoice.id})`
+        );
         setInvoices((prevInvoices) =>
           prevInvoices.map((i) =>
             i.id === editingInvoice.id ? { ...i, ...invoiceData } : i
@@ -3883,11 +3929,18 @@ const Invoices = ({ user, sessionToken }) => {
           method: "POST",
           data: invoiceData,
         });
+        console.log(
+          `Élément enregistré avec succès (ID: ${response.data.id})`
+        );
+        showToast(
+          `Élément enregistré avec succès (ID: ${response.data.id})`
+        );
         setInvoices((prevInvoices) => [response.data, ...prevInvoices]);
       }
       setShowInvoiceModal(false);
     } catch (error) {
       console.error("Error saving invoice:", error);
+      showToast(`Erreur: ${error.response?.data?.detail || error.message}`, true);
     }
   };
 
@@ -4152,7 +4205,7 @@ function App() {
   const handleLogin = async (sessionId) => {
     try {
       setLoading(true);
-      const response = await axios.post(`${API}/auth/login`, {
+      const response = await api.post('/auth/login', {
         session_id: sessionId,
       });
       setUser(response.data.user);
@@ -4178,7 +4231,7 @@ function App() {
     const token = localStorage.getItem("fleemy_session_token");
     if (token) {
       try {
-        const response = await axios.get(`${API}/auth/me`, {
+        const response = await api.get('/auth/me', {
           headers: { Authorization: `Bearer ${token}` },
         });
         setUser(response.data);

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Outlet } from 'react-router-dom';
-import axios from 'axios';
+import api from '../utils/api';
 import Sidebar from './Sidebar';
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
 
 export default function Layout() {
   const [user, setUser] = useState(null);
@@ -15,7 +13,7 @@ export default function Layout() {
     async function check() {
       if (token) {
         try {
-          const response = await axios.get(`${API}/auth/me`, {
+          const response = await api.get('/auth/me', {
             headers: { Authorization: `Bearer ${token}` },
           });
           setUser(response.data);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+
+const api = axios.create({
+  baseURL: `${API_URL}/api`,
+});
+
+export default api;

--- a/frontend/src/utils/toast.js
+++ b/frontend/src/utils/toast.js
@@ -1,0 +1,18 @@
+export function showToast(message, isError = false) {
+  const el = document.createElement('div');
+  el.textContent = message;
+  el.style.position = 'fixed';
+  el.style.bottom = '20px';
+  el.style.right = '20px';
+  el.style.background = isError ? '#dc3545' : '#16a34a';
+  el.style.color = '#fff';
+  el.style.padding = '10px 16px';
+  el.style.borderRadius = '4px';
+  el.style.zIndex = 9999;
+  el.style.transition = 'opacity 0.3s';
+  document.body.appendChild(el);
+  setTimeout(() => {
+    el.style.opacity = '0';
+    el.addEventListener('transitionend', () => el.remove());
+  }, 3000);
+}


### PR DESCRIPTION
## Summary
- switch environment variable to `REACT_APP_API_URL`
- use shared axios instance for API calls
- add visual toast notifications on save success/failure
- centralise API base URL
- update Layout to use API helper

## Testing
- `pytest -q`
- `CI=true npm start --silent`

------
https://chatgpt.com/codex/tasks/task_e_68849b51057083339483076720a0c82f