### PR TITLE
Add Firebase auth token interceptor

### DIFF
--- a/frontend/src/LegacyApp.js
+++ b/frontend/src/LegacyApp.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
-import api from "./utils/api";
+import api from "./api";
 import { showToast } from "./utils/toast";
 import { generateQuotePDF, generateInvoicePDF } from "./utils/pdf";
 import WeekNavigationHeader from "./components/WeekNavigationHeader";
@@ -171,7 +171,6 @@ const Dashboard = ({ user, sessionToken }) => {
     return await api({
       url,
       headers: {
-        Authorization: `Bearer ${sessionToken}`,
         "Content-Type": "application/json",
         ...options.headers,
       },
@@ -1429,7 +1428,6 @@ const Planning = ({ user, sessionToken }) => {
       return await api({
         url,
         headers: {
-          Authorization: `Bearer ${sessionToken}`,
           "Content-Type": "application/json",
           ...options.headers,
         },
@@ -2741,7 +2739,6 @@ const TodoList = ({ sessionToken }) => {
     return await api({
       url,
       headers: {
-        Authorization: `Bearer ${sessionToken}`,
         "Content-Type": "application/json",
         ...options.headers,
       },
@@ -3126,7 +3123,6 @@ const Quotes = ({ user, sessionToken }) => {
     return await api({
       url,
       headers: {
-        Authorization: `Bearer ${sessionToken}`,
         "Content-Type": "application/json",
         ...options.headers,
       },
@@ -3875,7 +3871,6 @@ const Invoices = ({ user, sessionToken }) => {
     return await api({
       url,
       headers: {
-        Authorization: `Bearer ${sessionToken}`,
         "Content-Type": "application/json",
         ...options.headers,
       },
@@ -4233,9 +4228,7 @@ function App() {
     const token = localStorage.getItem("fleemy_session_token");
     if (token) {
       try {
-        const response = await api.get("/auth/me", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const response = await api.get("/auth/me");
         setUser(response.data);
         setSessionToken(token);
       } catch (error) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { auth } from './firebase';
+
+const api = axios.create({
+  baseURL: 'http://localhost:8000/api',
+});
+
+api.interceptors.request.use(async (config) => {
+  if (auth.currentUser) {
+    try {
+      const token = await auth.currentUser.getIdToken();
+      config.headers = {
+        ...config.headers,
+        Authorization: `Bearer ${token}`,
+      };
+    } catch (e) {
+      // ignore token retrieval errors
+    }
+  }
+  return config;
+});
+
+export default api;

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Outlet } from 'react-router-dom';
-import api from '../utils/api';
+import api from '../api';
 import Sidebar from './Sidebar';
 
 
@@ -13,9 +13,7 @@ export default function Layout() {
     async function check() {
       if (token) {
         try {
-          const response = await api.get('/auth/me', {
-            headers: { Authorization: `Bearer ${token}` },
-          });
+          const response = await api.get('/auth/me');
           setUser(response.data);
           setSessionToken(token);
         } catch (e) {


### PR DESCRIPTION
## Summary
- create `frontend/src/api.js` with Axios instance
- use new API module in `Layout.jsx` and `LegacyApp.js`
- send Firebase Auth token automatically for all API requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ac3df90083338a640a9c584ad920