### PR TITLE
Refresh teams when cache is empty

### DIFF
--- a/frontend/src/utils/teamCache.js
+++ b/frontend/src/utils/teamCache.js
@@ -214,9 +214,11 @@ const fetchAndCacheTeams = async (fetcher) => {
 
 export const ensureTeamsCache = async (fetcher, { forceRefresh = false } = {}) => {
   const cachedTeams = readTeamsCache();
+  const hasCachedTeams = Array.isArray(cachedTeams) && cachedTeams.length > 0;
   const staleTeams = allowExpiredCacheRead();
+  const hasStaleTeams = Array.isArray(staleTeams) && staleTeams.length > 0;
 
-  if (!forceRefresh && cachedTeams !== null) {
+  if (!forceRefresh && hasCachedTeams) {
     return buildResult(cachedTeams, null, true, true);
   }
 
@@ -229,7 +231,7 @@ export const ensureTeamsCache = async (fetcher, { forceRefresh = false } = {}) =
       const result = await fetchAndCacheTeams(fetcher);
       return result;
     } catch (error) {
-      if (staleTeams !== null) {
+      if (hasStaleTeams) {
         return buildResult(staleTeams, null, true, true);
       }
 


### PR DESCRIPTION
## Summary
- avoid treating empty cached team lists as fresh data so membership updates are fetched
- only reuse stale cached teams when there is actual data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340b4872bc83338fc7e1641912b106)